### PR TITLE
feat: Implement list command

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,12 @@
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
 #include <nlohmann/json.hpp>
+#include <string>
 
 using json = nlohmann::json;
 
 void addEntry(const std::string &content);
+void listEntries();
 void showUsage(const std::string &appName);
 
 int main(int argc, char *argv[]) {
@@ -17,12 +17,20 @@ int main(int argc, char *argv[]) {
 
   std::string command = argv[1];
 
-  if (command == "add" && argc > 2) {
+  if (command == "add") {
+    if (argc <= 2) {
+      std::cerr << "Error: 'add' command requires content." << std::endl;
+      showUsage(argv[0]);
+      return 1;
+    }
     addEntry(argv[2]);
-  } else if (command == "add") {
-    std::cerr << "Error: 'add' command requires content." << std::endl;
-    showUsage(argv[0]);
-    return 1;
+  } else if (command == "list") {
+    if (argc != 2) {
+      std::cerr << "Error: 'list' command requires no argument." << std::endl;
+      showUsage(argv[0]);
+      return 1;
+    }
+    listEntries();
   } else {
     std::cerr << "Error: Unknown command '" << command << "'" << std::endl;
     showUsage(argv[0]);
@@ -38,16 +46,14 @@ void addEntry(const std::string &content) {
   if (inputFile.is_open()) {
     try {
       inputFile >> journalData;
-    } catch (const std::exception& e) {
+    } catch (const std::exception &e) {
       journalData = json::array();
     }
     inputFile.close();
   } else {
     journalData = json::array();
   }
-  json newEntry = {
-    {"content", content}
-  };
+  json newEntry = {{"content", content}};
   journalData.push_back(newEntry);
   std::ofstream outputFile("journal.json");
   if (outputFile.is_open()) {
@@ -59,8 +65,45 @@ void addEntry(const std::string &content) {
   }
 }
 
+void listEntries() {
+  std::ifstream inputFile("journal.json");
+  
+  if (!inputFile.is_open()) {
+    std::cout << "No journal entries found." << std::endl;
+    return;
+  }
+  try {
+    json journalData;
+    inputFile >> journalData;
+    inputFile.close();
+    if (!journalData.is_array() || journalData.empty()) {
+      std::cout << "No journal entries found." << std::endl;
+      return;
+    }
+    std::cout << "Journal Entries:" << std::endl;
+    std::cout << "================\n" << std::endl;
+    for (size_t i = 0; i < journalData.size(); ++i) {
+      const auto& entry = journalData[i];
+      std::cout << "Entry #" << (i + 1) << ":" << std::endl;
+      
+      if (entry.contains("content") && entry["content"].is_string()) {
+        std::cout << "  Content: " << entry["content"].get<std::string>() << std::endl;
+      } else {
+        std::cout << "  Content: (Invalid format)" << std::endl;
+      }
+      
+      std::cout << std::endl;
+    }
+    std::cout << "Total entries: " << journalData.size() << std::endl;
+  } catch (const std::exception& e) {
+    std::cerr << "Error reading journal file: " << e.what() << std::endl;
+    std::cout << "No valid journal entries found." << std::endl;
+  }
+}
+
 void showUsage(const std::string &appName) {
   std::cerr << "Usage: " << appName << " <command> [arguments]" << std::endl;
   std::cerr << "Commands:" << std::endl;
   std::cerr << "  add \"<content>\"    Add a new journal entry." << std::endl;
+  std::cerr << "  list             List all journal entries." << std::endl;
 }


### PR DESCRIPTION
# Implement List Functionality for MemoCLI

## Description
This PR adds the `list` command functionality to the MemoCLI application, allowing users to view all journal entries stored in the JSON file.

## Changes Made

### 1. New Function Implementation
- Added `listEntries()` function that:
  - Reads and parses `journal.json` file
  - Handles file not found and empty file cases gracefully
  - Validates JSON structure and entry format
  - Displays entries in a user-friendly format with numbering
  - Includes comprehensive error handling

### 2. Main Function Updates
- Enhanced command parsing logic for better argument validation
- Added proper error handling for `list` command with arguments
- Integrated `listEntries()` function call

### 3. Code Quality Improvements
- Reorganized include statements for better readability
- Improved error messages and user feedback
- Added usage documentation for the new `list` command
- Maintained consistent code formatting throughout

### 4. Key Features
- **Robust Error Handling**: Handles missing files, invalid JSON, and malformed entries
- **User-Friendly Output**: Clean formatting with entry numbers and separation
- **Input Validation**: Prevents misuse of `list` command with arguments
- **Backward Compatibility**: Fully compatible with existing `add` functionality

## Testing
The implementation has been tested with:
- Empty journal files
- Invalid JSON formats
- Multiple entry scenarios
- Error condition handling

## Usage
```bash
# List all journal entries
./memocli list

# Example output:
Journal Entries:
================

Entry #1:
  Content: My first memo

Entry #2:
  Content: Another entry

Total entries: 2
